### PR TITLE
Add run script to remove frameworks

### DIFF
--- a/DBEmptyState.xcodeproj/project.pbxproj
+++ b/DBEmptyState.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 				C634F9A51EA9D7210016232D /* Resources */,
 				C6878D0E1EB8B8100065CDD2 /* 📦 Carthage Copy */,
 				C656817C1EBC7AE800F5E20F /* 🚧 Swift Lint */,
+				958182401F2B65E600D24877 /* ✂️ Remove Frameworks File */,
 			);
 			buildRules = (
 			);
@@ -403,6 +404,20 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		958182401F2B65E600D24877 /* ✂️ Remove Frameworks File */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "✂️ Remove Frameworks File";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ $CONFIGURATION == \"Release\" ]; then\necho \"✂️Remove Frameworks File: ${CONFIGURATION}\"\ncd \"${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/\"\nif [[ -d \"Frameworks\" ]]; then\nrm -fr Frameworks\nfi\nfi";
+		};
 		C656817C1EBC7AE800F5E20F /* 🚧 Swift Lint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;


### PR DESCRIPTION
This fixes an "Duplicate Symbols" error wich occurs if the including project is including frameworks used by DBEmptyState aswell.